### PR TITLE
Change the order in the curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Path | Courses | Difficulty | Type
 Ruby |[Try Ruby](http://tryruby.org/)|Easy | Web
 Ruby|[Ruby - Codecademy](https://www.codecademy.com/tracks/ruby)|Easy | Web
 HTML & CSS|[HTML & CSS - Codecademy](https://www.codecademy.com/tracks/web)|Easy| Web
+Rails |[Learn Ruby on Rails (Daniel Kehoe)](http://learn-rails.com/learn-ruby-on-rails.html)| Very Easy| Book
 Rails |[Rails for Zombies Redux](https://www.codeschool.com/courses/rails-for-zombies-redux)|Easy | Video
 Rails |[Ruby on Rails Tutorial](https://www.railstutorial.org/)|Easy| Book & Video
-Rails |[Learn Ruby on Rails (Daniel Kehoe)](http://learn-rails.com/learn-ruby-on-rails.html)| Very Easy| Book
 
 #### Additional
 Path | Courses | Difficulty | Type


### PR DESCRIPTION
Apparently, Learn Ruby on Rails (Daniel Kehoe) is easier than Ruby on Rails Tutorial by Michael Hartl. And if the order in the curriculum is important, Daniel Kehoe's book should precede.